### PR TITLE
Fix: Handle undefined attributes

### DIFF
--- a/src/__snapshots__/transform.test.js.snap
+++ b/src/__snapshots__/transform.test.js.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`transform handles empty attributes 1`] = `
+"interface TestAttributes {
+    readonly style?: Record<string, any>;
+}"
+`;
+
 exports[`transform prints attribute type declaration 1`] = `
 "interface TestAttributes {
     readonly stringAttribute?: string;

--- a/src/transform.js
+++ b/src/transform.js
@@ -78,20 +78,26 @@ const getTypeReferenceOfAttribute = (attribute) => {
 const createAttributesInterface = ( blockMetadata, InterfaceName ) => {
 	const attributes = blockMetadata.attributes;
 
-	const attributesProperties = Object.keys(attributes).map((attributeName) => {
-		const attribute = attributes[attributeName];
-		const { type, default: defaultValue, enum: typeEnum } = attribute;
-		const hasDefaultValue = defaultValue !== undefined;
+	const attributesProperties = [];
 
-		const typeReference = getTypeReferenceOfAttribute(attribute);
+	if ( attributes && Object.keys(attributes).length ) {
+		Object.keys(attributes).forEach((attributeName) => {
+			const attribute = attributes[attributeName];
+			const { type, default: defaultValue, enum: typeEnum } = attribute;
+			const hasDefaultValue = defaultValue !== undefined;
 
-		return ts.factory.createPropertySignature(
-			[readonlyModifier],
-			ts.factory.createIdentifier(attributeName),
-			hasDefaultValue ? undefined : ts.factory.createToken(ts.SyntaxKind.QuestionToken),
-			typeReference,
-		);
-	});
+			const typeReference = getTypeReferenceOfAttribute(attribute);
+
+			const property = ts.factory.createPropertySignature(
+				[readonlyModifier],
+				ts.factory.createIdentifier(attributeName),
+				hasDefaultValue ? undefined : ts.factory.createToken(ts.SyntaxKind.QuestionToken),
+				typeReference,
+			);
+
+			attributesProperties.push(property);
+		});
+	}
 
 	const styleAttribute = ts.factory.createPropertySignature(
 		[readonlyModifier],

--- a/src/transform.test.js
+++ b/src/transform.test.js
@@ -59,6 +59,14 @@ describe('transform', () => {
 		expect(typeDeclarationString).toMatchSnapshot();
 	});
 
+	test('handles empty attributes', () => {
+		const typeDeclaration = createAttributesInterface({}, 'TestAttributes');
+
+		const typeDeclarationString = printTypeDeclaration(typeDeclaration);
+
+		expect(typeDeclarationString).toMatchSnapshot();
+	})
+
 	test('prints block context type declaration', () => {
 		const contextPropertyDeclaration = createContextInterface({}, 'TestContext');
 		const typeDeclarationString = printTypeDeclaration(contextPropertyDeclaration);


### PR DESCRIPTION
Blocks don't necessarily need to have attributes defined. This handles empty / undefined attributes